### PR TITLE
Add `perspective` and `learnBlend` parameters and enhance engine audio synthesis

### DIFF
--- a/app.js
+++ b/app.js
@@ -122,7 +122,8 @@ const CONFIG = {
     realVehicleMode: false,
     accelThreshold: 0.5,
     accelMax: 5.0,
-    cruiseThrottle: 0.15
+    cruiseThrottle: 0.15,
+    learnBlend: 0.35
   }
 };
 
@@ -182,7 +183,8 @@ const params = {
   realVehicleMode: CONFIG.defaults.realVehicleMode,
   accelThreshold: CONFIG.defaults.accelThreshold,
   accelMax: CONFIG.defaults.accelMax,
-  cruiseThrottle: CONFIG.defaults.cruiseThrottle
+  cruiseThrottle: CONFIG.defaults.cruiseThrottle,
+  learnBlend: CONFIG.defaults.learnBlend
 };
 
 // Vehicle state for simple load and speed modeling
@@ -964,6 +966,8 @@ function update() {
     const loadParam = engineNode.parameters.get('load');
     const v8ModeParam = engineNode.parameters.get('v8Mode');
     const rotaryModeParam = engineNode.parameters.get('rotaryMode');
+    const perspectiveParam = engineNode.parameters.get('perspective');
+    const learnBlendParam = engineNode.parameters.get('learnBlend');
 
     const now = audioCtx.currentTime;
     rpmParam.setValueAtTime(params.currentRpm, now);
@@ -978,6 +982,11 @@ function update() {
     loadParam.setValueAtTime(params.load, now);
     if (v8ModeParam) v8ModeParam.setValueAtTime(params.enginePreset === 'v8' ? 1 : 0, now);
     if (rotaryModeParam) rotaryModeParam.setValueAtTime(params.enginePreset === 'rotary' ? 1 : 0, now);
+    if (perspectiveParam) {
+      const perspectiveValue = params.audioPerspective === 'interior' ? 1 : (params.audioPerspective === 'enginebay' ? 2 : 0);
+      perspectiveParam.setValueAtTime(perspectiveValue, now);
+    }
+    if (learnBlendParam) learnBlendParam.setValueAtTime(params.learnBlend, now);
   }
 
   // Update UI

--- a/engine-processor.js
+++ b/engine-processor.js
@@ -215,6 +215,8 @@ class EngineProcessor extends AudioWorkletProcessor {
     // Rev limiter state
     this.revLimiterCycle = 0;
     this.revLimiterActive = false;
+    this.transientPulse = 0;
+    this.learnedEqState = 0;
   }
 
   static get parameterDescriptors() {
@@ -230,7 +232,9 @@ class EngineProcessor extends AudioWorkletProcessor {
       { name: 'redlineRpm', defaultValue: 7000, minValue: 3000, maxValue: 12000 },
       { name: 'load', defaultValue: 0, minValue: 0, maxValue: 1 },
       { name: 'v8Mode', defaultValue: 0, minValue: 0, maxValue: 1 },
-      { name: 'rotaryMode', defaultValue: 0, minValue: 0, maxValue: 1 }
+      { name: 'rotaryMode', defaultValue: 0, minValue: 0, maxValue: 1 },
+      { name: 'perspective', defaultValue: 0, minValue: 0, maxValue: 2 },
+      { name: 'learnBlend', defaultValue: 0, minValue: 0, maxValue: 1 }
     ];
   }
 
@@ -257,6 +261,8 @@ class EngineProcessor extends AudioWorkletProcessor {
       const load = getParamValue(parameters.load, i);
       const v8Mode = getParamValue(parameters.v8Mode, i);
       const rotaryMode = getParamValue(parameters.rotaryMode, i);
+      const perspective = getParamValue(parameters.perspective, i);
+      const learnBlend = getParamValue(parameters.learnBlend, i);
 
       // Rev limiter simulation: fuel cut at redline
       let revLimiterCut = 1.0;
@@ -289,6 +295,11 @@ class EngineProcessor extends AudioWorkletProcessor {
       if (this.phase > 2.0 * Math.PI) {
         this.phase -= 2.0 * Math.PI;
       }
+
+      // Event-driven ignition transient for stronger character differences
+      const phasePulse = Math.max(0, Math.sin(this.phase));
+      const transientExcite = Math.pow(phasePulse, 14.0) * (0.12 + 0.22 * throttle + 0.18 * load);
+      this.transientPulse = Math.max(this.transientPulse * SynthConstants.TRANSIENT_DECAY, transientExcite);
 
       // 2. Harmonic Synthesis (Anti-aliased)
       // VTEC profile: blend from low-cam tone to high-cam tone around crossover RPM.
@@ -512,18 +523,33 @@ class EngineProcessor extends AudioWorkletProcessor {
       const exhaustResonance = SynthConstants.EXHAUST_RES1_GAIN * this.exhaustRes1State + SynthConstants.EXHAUST_RES2_GAIN * this.exhaustRes2State + SynthConstants.EXHAUST_RES3_GAIN * this.exhaustRes3State;
       signal += exhaustResonance * (SynthConstants.EXHAUST_RESONANCE_BASE + SynthConstants.EXHAUST_RESONANCE_THROTTLE * throttle);
 
+      // Dynamic formant sweep across RPM/load + perspective coloration
+      const rpmNormFormant = Math.min(1.0, rpm / Math.max(1.0, redlineRpm));
+      const perspectiveTilt = perspective === 1 ? -0.1 : (perspective >= 2 ? 0.15 : 0.0);
+      const formantSweep = 0.7 + SynthConstants.FORMANT_SWEEP_SCALE * (rpmNormFormant + throttle * 0.7 + load * 0.5 + perspectiveTilt);
+      signal += exhaustResonance * formantSweep + this.transientPulse * (0.16 + 0.14 * throttle);
+
       // Apply rev limiter cut (simulates fuel cut)
       signal *= revLimiterCut;
 
       // 5. Distortion
       // Under load, engine runs harder and produces more distortion
       const drive = SynthConstants.DISTORTION_BASE + SynthConstants.DISTORTION_THROTTLE * throttle + SynthConstants.DISTORTION_VTEC * vtecBlend + SynthConstants.DISTORTION_FA24 * fa24Mode + SynthConstants.DISTORTION_LOAD * loadStress;
-      signal = Math.tanh(drive * signal);
+      const lowBand = Math.tanh((drive * 0.85) * signal);
+      const midBand = Math.tanh((drive * 1.1) * (signal + 0.08 * this.bpfState));
+      const hiBand = Math.tanh((drive * 0.65) * (signal - this.lpfState));
+      signal = lowBand * 0.55 + midBand * 0.35 + hiBand * 0.10;
 
       // Post-filter distortion output to reduce buzzy high-RPM edge
       const postLpfAlpha = SynthConstants.POST_LPF_ALPHA_BASE + SynthConstants.POST_LPF_ALPHA_THROTTLE * throttle;
       this.postLpfState += postLpfAlpha * (signal - this.postLpfState);
       signal = SynthConstants.POST_LPF_MIX_FILTERED * this.postLpfState + SynthConstants.POST_LPF_MIX_DRY * signal;
+
+      // Learned-style correction (lightweight surrogate)
+      const blend = Math.min(1.0, Math.max(0.0, learnBlend));
+      const targetEq = (this.lpfState * 0.22) - (hpf * 0.08) + (combustionNoise * 0.12);
+      this.learnedEqState += 0.04 * (targetEq - this.learnedEqState);
+      signal = signal * (1.0 - SynthConstants.LEARN_BLEND_MAX * blend) + this.learnedEqState * (SynthConstants.LEARN_BLEND_MAX * blend);
 
       // Volume scaling
       signal *= SynthConstants.MASTER_VOLUME;


### PR DESCRIPTION
### Motivation
- Expose new controls for audio coloration and lightweight learned correction to allow different listening perspectives and blended learned EQ behavior. 
- Improve transient and formant behavior to provide stronger ignition transients and perspective-dependent timbre. 
- Reduce harsh high-RPM artifacts with a multi-band distortion/post-filtering approach to yield a more organic engine sound.

### Description
- Added new default `learnBlend` to `CONFIG.defaults` and wired `params.learnBlend` in `app.js` so the UI/params expose a `learnBlend` control. 
- Mapped a new `perspective` AudioWorklet parameter in `app.js` using `audioPerspective` values (`0` exterior, `1` interior, `2` enginebay) and also exposed `learnBlend` to the worklet. 
- Extended `EngineProcessor` with new state (`transientPulse`, `learnedEqState`), registered new parameters `perspective` and `learnBlend`, computed an event-driven ignition transient, and applied a perspective-aware formant sweep. 
- Reworked distortion into a three-band tanh mix to soften high-RPM edges and added a lightweight learned-style EQ correction blended by `learnBlend` to subtly shape output based on internal states. 

### Testing
- Ran the project build with `npm run build` which completed successfully. 
- Executed the test suite with `npm test` and all tests passed. 
- Ran `npm run lint` and static checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f18dea08ec8325ad702b3da121d9ad)